### PR TITLE
Use local high-res geojson

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,9 +106,8 @@
       const shapes = [];
       const countryShapes = {};
 
-      fetch(
-        "https://raw.githubusercontent.com/johan/world.geo.json/master/countries.geo.json",
-      )
+      // Load the high resolution country polygons shipped with the project
+      fetch("countries.geo.json")
         .then((r) => r.json())
         .then((data) => {
           countries = data.features.map((f) => {


### PR DESCRIPTION
## Summary
- use the `countries.geo.json` file in the repo instead of the lower-resolution remote file

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b56a68428832793977b7d87507340