### PR TITLE
Switch to free Stamen tile layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,19 +90,19 @@
           maxZoom: 20,
         },
       );
-      var Stadia_StamenTonerLines = L.tileLayer(
-        "https://tiles.stadiamaps.com/tiles/stamen_toner_lines/{z}/{x}/{y}{r}.{ext}",
+      var Stamen_TonerLines = L.tileLayer(
+        "https://stamen-tiles-{s}.a.ssl.fastly.net/toner-lines/{z}/{x}/{y}.png",
         {
+          subdomains: "abcd",
           minZoom: 0,
           maxZoom: 20,
           attribution:
-            '&copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a> &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a> &copy; <a href="https://openmaptiles.org/" target="_blank">OpenMapTiles</a> &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-          ext: "png",
+            'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
         },
       );
 
       const map = L.map("map", {
-        layers: [CartoDB_PositronNoLabels, Stadia_StamenTonerLines],
+        layers: [CartoDB_PositronNoLabels, Stamen_TonerLines],
       }).setView([20, 0], 2);
 
       // GeoJSON data for country polygons


### PR DESCRIPTION
## Summary
- remove paywalled Stadiamaps tiles
- use Stamen's toner lines for borders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cea3bf0fc8327ad60bc1f005bb0b9